### PR TITLE
CI/ yarn build시 NEXT_PUBLIC_API_BASE_URL 값 추가

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -72,6 +72,8 @@ jobs:
 
     - name: Build application
       run: yarn build
+      env:
+        NEXT_PUBLIC_API_BASE_URL: https://be.logonme.click/api/v1
 
     # ✅ 배포용 tar.gz 생성
     - name: Create deployment archive


### PR DESCRIPTION
- NEXT_PUBLIC_API_BASE_URL 환경변수는 런타임이 아니라 빌드타임에 설정되어야함
```
# https://kakao.gg/tech/data/684b6b7570cd5c72c76bd60e
처리 방식: Next.js는 빌드 시점에 NEXT_PUBLIC으로 시작하는 모든 환경 변수의 값을 JavaScript 코드에 그대로 삽입(inlining)합니다. 즉, 최종적으로 생성된 JS 파일 안에 변수 값이 텍스트로 포함됩니다.
```
- 따라서 배포용 빌드시 적용되도록 업데이트